### PR TITLE
[Feature] Support sequence parallel for reward model, dpo and orpo.

### DIFF
--- a/xtuner/model/modules/dispatch/internlm2.py
+++ b/xtuner/model/modules/dispatch/internlm2.py
@@ -286,8 +286,13 @@ def internlm2_varlen_attn_forward(
 
     assert SUPPORT_FLASH2
     if use_varlen_atten:
-        attn_output = varlen_flash_attn(query_states, key_states, value_states,
-                                        cumulative_len, max_seqlen)
+        attn_output = varlen_flash_attn(
+            query_states,
+            key_states,
+            value_states,
+            cumulative_len,
+            max_seqlen,
+            training=self.training)
     else:
         # import ipdb; ipdb.set_trace()
         attn_output = flash_attn_wo_mask(

--- a/xtuner/model/modules/dispatch/llama.py
+++ b/xtuner/model/modules/dispatch/llama.py
@@ -379,14 +379,15 @@ def llama_varlen_attn_forward(
             cumulative_len,
             max_seqlen,
             causal=True,
-            dropout_p=dropout_rate)
+            dropout_p=dropout_rate,
+            training=self.training)
     else:
         attn_output = flash_attn_wo_mask(
             query_states,
             key_states,
             value_states,
             causal=True,
-            training=False)
+            training=self.training)
 
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
     attn_output = self.o_proj(attn_output)
@@ -501,7 +502,8 @@ def llama_varlen_attn_forward_legacy(
             cumulative_len,
             max_seqlen,
             causal=True,
-            dropout_p=dropout_rate)
+            dropout_p=dropout_rate,
+            training=self.training)
     else:
         attn_output = flash_attn_wo_mask(
             query_states,
@@ -509,7 +511,7 @@ def llama_varlen_attn_forward_legacy(
             value_states,
             causal=True,
             dropout_p=dropout_rate,
-            training=False)
+            training=self.training)
 
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
 

--- a/xtuner/model/modules/dispatch/mistral.py
+++ b/xtuner/model/modules/dispatch/mistral.py
@@ -395,7 +395,7 @@ def mistral_varlen_attn_forward(
             causal=causal,
             dropout_p=dropout_rate,
             window_size=window_size,
-            training=True)
+            training=self.training)
     else:
         attn_output = flash_attn_wo_mask(
             query_states,
@@ -404,7 +404,7 @@ def mistral_varlen_attn_forward(
             causal=causal,
             dropout_p=dropout_rate,
             window_size=window_size,
-            training=False)
+            training=self.training)
 
     # ---------------- flash attention forward end ------------------- #
 

--- a/xtuner/model/modules/dispatch/phi3.py
+++ b/xtuner/model/modules/dispatch/phi3.py
@@ -430,7 +430,7 @@ def phi3_varlen_attn_forward(
             causal=causal,
             dropout_p=attn_dropout,
             window_size=window_size,
-            training=True)
+            training=self.training)
     else:
         attn_output = flash_attn_wo_mask(
             query_states,
@@ -439,7 +439,7 @@ def phi3_varlen_attn_forward(
             causal=causal,
             dropout_p=attn_dropout,
             window_size=window_size,
-            training=False)
+            training=self.training)
 
     # ---------------- flash attention forward end ------------------- #
 

--- a/xtuner/model/modules/dispatch/qwen2.py
+++ b/xtuner/model/modules/dispatch/qwen2.py
@@ -322,7 +322,7 @@ def qwen2_varlen_attn_forward(
             causal=causal,
             dropout_p=dropout_rate,
             window_size=window_size,
-            training=True)
+            training=self.training)
     else:
         attn_output = flash_attn_wo_mask(
             query_states,
@@ -331,7 +331,7 @@ def qwen2_varlen_attn_forward(
             causal=causal,
             dropout_p=dropout_rate,
             window_size=window_size,
-            training=False)
+            training=self.training)
 
     # ---------------- flash attention forward end ------------------- #
 

--- a/xtuner/model/orpo.py
+++ b/xtuner/model/orpo.py
@@ -131,7 +131,7 @@ class ORPO(SupervisedFinetune):
         return data
 
     def compute_loss(self, data, data_samples=None):
-        # labels = data.pop('labels')
+        labels_ori = data.pop('labels')
 
         if get_sequence_parallel_world_size() > 1:
             data = self._split_for_sequence_parallel(data)
@@ -145,9 +145,9 @@ class ORPO(SupervisedFinetune):
                 grad_scale='up')
 
         if not self.use_varlen_attn:
-            chosen_nll_loss = self.cross_entropy_loss(
-                all_logits[::2], data['labels'].clone()[::2])
-            labels = data['labels'].clone()
+            chosen_nll_loss = self.cross_entropy_loss(all_logits[::2],
+                                                      labels_ori.clone()[::2])
+            labels = labels_ori.clone()
             labels[labels == -100] = 0
             loss_mask = labels != 0
             chosen_logps, rejected_logps = self.get_logps(
@@ -167,20 +167,19 @@ class ORPO(SupervisedFinetune):
                 logits = torch.split(all_logits, seqlens, dim=1)[:-1]
                 assert len(logits) % 2 == 0
                 chosen_logits = logits[::2]
-                labels = torch.split(
-                    data['labels'].clone(), seqlens, dim=1)[:-1]
+                labels = torch.split(labels_ori.clone(), seqlens, dim=1)[:-1]
                 assert len(labels) % 2 == 0
                 chosen_labels = labels[::2]
             else:
                 chosen_logits = torch.split(all_logits, seqlens, dim=1)[::2]
                 chosen_labels = torch.split(
-                    data['labels'].clone(), seqlens, dim=1)[::2]
+                    labels_ori.clone(), seqlens, dim=1)[::2]
 
             chosen_logits = torch.cat(chosen_logits, dim=1)
             chosen_labels = torch.cat(chosen_labels, dim=1)
             chosen_nll_loss = self.cross_entropy_loss(chosen_logits,
                                                       chosen_labels)
-            labels = data['labels'].clone()
+            labels = labels_ori.clone()
             labels[labels == -100] = 0
             loss_mask = labels != 0
             chosen_logps, rejected_logps = self.get_var_len_atten_logps(
@@ -191,9 +190,9 @@ class ORPO(SupervisedFinetune):
         losses = losses.mean()
         # skip nan loss
         if torch.isnan(chosen_nll_loss):
-            chosen_nll_loss = torch.zeros_like(chosen_nll_loss)
+            chosen_nll_loss = all_logits.mean() * 0
         if torch.isnan(losses):
-            losses = torch.zeros_like(losses)
+            losses = all_logits.mean() * 0
         loss = chosen_nll_loss - losses
 
         reward_acc = (chosen_rewards > rejected_rewards).float().mean()

--- a/xtuner/parallel/sequence/__init__.py
+++ b/xtuner/parallel/sequence/__init__.py
@@ -7,7 +7,8 @@ from .attention import (post_process_for_sequence_parallel_attn,
 from .comm import (all_to_all, gather_for_sequence_parallel,
                    gather_forward_split_backward, split_for_sequence_parallel,
                    split_forward_gather_backward)
-from .data_collate import pad_for_sequence_parallel
+from .data_collate import (pad_cumulative_len_for_sequence_parallel,
+                           pad_for_sequence_parallel)
 from .reduce_loss import reduce_sequence_parallel_loss
 from .sampler import SequenceParallelSampler
 from .setup_distributed import (get_data_parallel_group,
@@ -27,5 +28,6 @@ __all__ = [
     'get_data_parallel_group', 'get_data_parallel_world_size',
     'get_data_parallel_rank', 'reduce_sequence_parallel_loss', 'init_dist',
     'all_to_all', 'gather_for_sequence_parallel',
-    'split_forward_gather_backward', 'gather_forward_split_backward'
+    'split_forward_gather_backward', 'gather_forward_split_backward',
+    'pad_cumulative_len_for_sequence_parallel'
 ]

--- a/xtuner/parallel/sequence/data_collate.py
+++ b/xtuner/parallel/sequence/data_collate.py
@@ -18,3 +18,29 @@ def pad_for_sequence_parallel(tensor, padding_value, dim=-1):
         pad_shape, padding_value, dtype=tensor.dtype, device=tensor.device)
     tensor = torch.cat([tensor, pad], dim=dim)
     return tensor
+
+
+# This function only meets the following two conditions:
+# 1. use_varlen_attn = True
+# 2. pack_to_max_length = True and the lengths of each sequence are different
+def pad_cumulative_len_for_sequence_parallel(cumulative_len):
+    assert len(cumulative_len) == 1
+    seqlen = cumulative_len[0][-1]
+    seq_parallel_world_size = get_sequence_parallel_world_size()
+    if seqlen % seq_parallel_world_size == 0:
+        return cumulative_len, None
+
+    bs = len(cumulative_len)
+    pad_len = seq_parallel_world_size - (seqlen % seq_parallel_world_size)
+    seqlen_new = seqlen + pad_len
+    attention_mask = torch.zeros(
+        bs, seqlen_new, dtype=torch.bool, device=cumulative_len[0].device)
+    attention_mask[:, :seqlen] = True
+
+    for i, cu_len in enumerate(cumulative_len):
+        pad = torch.tensor([seqlen_new],
+                           device=cu_len.device,
+                           dtype=cu_len.dtype)
+        cumulative_len[i] = torch.cat([cu_len, pad], dim=0)
+
+    return cumulative_len, attention_mask


### PR DESCRIPTION
# Usage 

```diff
#######################################################################
#                          PART 1  Settings                           #
#######################################################################
+ from xtuner.parallel.sequence import SequenceParallelSampler

+ # parallel
+ sequence_parallel_size = 2

accumulative_counts = 16
+ accumulative_counts *= sequence_parallel_size

...
#######################################################################
#                      PART 3  Dataset & Dataloader                   #
#######################################################################

sampler = SequenceParallelSampler \
    if sequence_parallel_size > 1 else DefaultSampler

train_dataloader = dict(
-    sampler=dict(type=DefaultSampler, shuffle=True),
+   sampler=dict(type=sampler, shuffle=True),
)
```

# Notes

DeepSpeed is needed to ensure training accuracy.

```
# On a single GPU
xtuner train ${CONFIG_NAME_OR_PATH} --deepspeed deepspeed_zero1
# On multiple GPUs
(DIST) NPROC_PER_NODE=${GPU_NUM} xtuner train ${CONFIG_NAME_OR_PATH} --deepspeed deepspeed_zero1
(SLURM) srun ${SRUN_ARGS} xtuner train ${CONFIG_NAME_OR_PATH} --launcher slurm --deepspeed deepspeed_zero1

```
